### PR TITLE
model.load_state_dict complatible with newer transformers version

### DIFF
--- a/trial2vec/model.py
+++ b/trial2vec/model.py
@@ -838,7 +838,7 @@ class Trial2Vec(TrialSearchBase):
             config = self._load_model_config(config_filename)
             self.config.update(config)
             self.model.config.update({'fields':config['fields'], 'ctx_fields':config['ctx_fields']})
-        self.model.load_state_dict(state_dict['model'])
+        self.model.load_state_dict(state_dict['model'], , strict=False)
         self.trial_embs = state_dict['emb']
 
     def save_model(self, output_dir):


### PR DESCRIPTION
newer versions of the transformer library break the model.loca_state_dict function as is.  To solve it, add the parameter, strict=False as suggested in https://stackoverflow.com/questions/68453123/runtimeerror-errors-in-loading-state-dict-for-dataparallel-unexpected-keys